### PR TITLE
PR for adding more additional ci testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
         effective_population_size: ['11418','11000']
         mutation_rate: ['1','2']
         gwas_pheno_trait_type: ['binary', 'quantitative']
-        gwas_heritability: ['0.1','0.2']
-        gwas_disease_prevalance: ['0.1','0.2']
         gwas_simulation_replicates: ['1', '2']
     steps:
       - uses: actions/checkout@v1
@@ -36,6 +34,6 @@ jobs:
           sudo mv nextflow /usr/local/bin/
       - name: Run pipeline with basic test profile and various optional flags 
         run: |
-          nextflow run ${GITHUB_WORKSPACE} --effective_population_size ${{ matrix.effective_population_size }} --mutation_rate ${{ matrix.mutation_rate }} --gwas_pheno_trait_type ${{ matrix.gwas_pheno_trait_type }} --gwas_heritability ${{ matrix.gwas_heritability }} --gwas_disease_prevalance ${{ matrix.gwas_disease_prevalance }} --gwas_simulation_replicates ${{ matrix.gwas_simulation_replicates }}  -profile test
+          nextflow run ${GITHUB_WORKSPACE} --effective_population_size ${{ matrix.effective_population_size }} --mutation_rate ${{ matrix.mutation_rate }} --gwas_pheno_trait_type ${{ matrix.gwas_pheno_trait_type }} --gwas_simulation_replicates ${{ matrix.gwas_simulation_replicates }}  -profile test
 
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        effective_population_size: ['11418','11000']
+        effective_population_size: [11418, 11000]
         gwas_pheno_trait_type: ['binary', 'quantitative']
         gwas_simulation_replicates: ['1', '2']
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,17 @@ jobs:
       - name: Run pipeline with basic test profile and various optional flags 
         run: |
           nextflow run ${GITHUB_WORKSPACE} --effective_population_size ${{ matrix.effective_population_size }} --gwas_pheno_trait_type ${{ matrix.gwas_pheno_trait_type }} --gwas_simulation_replicates ${{ matrix.gwas_simulation_replicates }}  -profile test
+  cohort_browser_output_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Nextflow
+        run: |
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+      - name: Run pipeline with cohort browser simulation profile 
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} -profile cb
+
 
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
     strategy:
       matrix:
         effective_population_size: ['11418','11000']
-        mutation_rate: ['1','2']
         gwas_pheno_trait_type: ['binary', 'quantitative']
         gwas_simulation_replicates: ['1', '2']
     steps:
@@ -34,6 +33,6 @@ jobs:
           sudo mv nextflow /usr/local/bin/
       - name: Run pipeline with basic test profile and various optional flags 
         run: |
-          nextflow run ${GITHUB_WORKSPACE} --effective_population_size ${{ matrix.effective_population_size }} --mutation_rate ${{ matrix.mutation_rate }} --gwas_pheno_trait_type ${{ matrix.gwas_pheno_trait_type }} --gwas_simulation_replicates ${{ matrix.gwas_simulation_replicates }}  -profile test
+          nextflow run ${GITHUB_WORKSPACE} --effective_population_size ${{ matrix.effective_population_size }} --gwas_pheno_trait_type ${{ matrix.gwas_pheno_trait_type }} --gwas_simulation_replicates ${{ matrix.gwas_simulation_replicates }}  -profile test
 
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gwas_pheno_trait_type: ['binary', 'quantitative']
         effective_population_size: ['11418','11000']
+        mutation_rate: ['1','2']
+        gwas_pheno_trait_type: ['binary', 'quantitative']
+        gwas_heritability: ['0.1','0.2']
+        gwas_disease_prevalance: ['0.1','0.2']
+        gwas_simulation_replicates: ['1', '2']
     steps:
       - uses: actions/checkout@v1
       - name: Install Nextflow
@@ -32,6 +36,6 @@ jobs:
           sudo mv nextflow /usr/local/bin/
       - name: Run pipeline with basic test profile and various optional flags 
         run: |
-          nextflow run ${GITHUB_WORKSPACE} --gwas_pheno_trait_type ${{ matrix.gwas_pheno_trait_type }} --effective_population_size ${{ matrix.effective_population_size }} -profile test
+          nextflow run ${GITHUB_WORKSPACE} --effective_population_size ${{ matrix.effective_population_size }} --mutation_rate ${{ matrix.mutation_rate }} --gwas_pheno_trait_type ${{ matrix.gwas_pheno_trait_type }} --gwas_heritability ${{ matrix.gwas_heritability }} --gwas_disease_prevalance ${{ matrix.gwas_disease_prevalance }} --gwas_simulation_replicates ${{ matrix.gwas_simulation_replicates }}  -profile test
 
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        effective_population_size: [11418, 11000]
+        effective_population_size: ['11418', '11000']
         gwas_pheno_trait_type: ['binary', 'quantitative']
         gwas_simulation_replicates: ['1', '2']
     steps:

--- a/conf/cb.config
+++ b/conf/cb.config
@@ -1,0 +1,37 @@
+/*
+ * ---------------------------------------------------------------------
+ *  lifebit-ai/simulate cb config file
+ * ---------------------------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ * nextflow run main.nf -profile cb
+ */
+
+
+docker.enabled = true
+
+params  {
+    num_participants = 40
+    simulate_vcf = true
+    simulate_plink = true
+    simulate_gwas_sum_stats = true
+    gwas_cases = 20
+    gwas_controls = 20
+    reference_1000G = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/simulate-ci-testing/ALL_1000G_phase1integrated_v3_impute.tgz"
+    legend_for_hapgen2 = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/simulate-ci-testing/all_leg_chr21.tar.gz"
+    simulate_cb_output = true
+    simulate_cb_output_config = "https://testdata-magda.s3-eu-west-1.amazonaws.com/simulate-ci-testing/simulate_cb_output_config.yml"
+    simulate_cb_output_output_tag = 'simulated'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus = 2
+}
+
+process {
+
+  withLabel: high_memory {
+    cpus = 2
+  }
+
+}
+

--- a/conf/cb.config
+++ b/conf/cb.config
@@ -20,7 +20,7 @@ params  {
     reference_1000G = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/simulate-ci-testing/ALL_1000G_phase1integrated_v3_impute.tgz"
     legend_for_hapgen2 = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/simulate-ci-testing/all_leg_chr21.tar.gz"
     simulate_cb_output = true
-    simulate_cb_output_config = "https://testdata-magda.s3-eu-west-1.amazonaws.com/simulate-ci-testing/simulate_cb_output_config.yml"
+    simulate_cb_output_config = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/simulate-ci-testing/simulate_cb_output_config.yml"
     simulate_cb_output_output_tag = 'simulated'
 
     // Limit resources so that this can run on GitHub Actions
@@ -34,4 +34,3 @@ process {
   }
 
 }
-

--- a/conf/cb.config
+++ b/conf/cb.config
@@ -20,7 +20,7 @@ params  {
     reference_1000G = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/simulate-ci-testing/ALL_1000G_phase1integrated_v3_impute.tgz"
     legend_for_hapgen2 = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/simulate-ci-testing/all_leg_chr21.tar.gz"
     simulate_cb_output = true
-    simulate_cb_output_config = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/simulate-ci-testing/simulate_cb_output_config.yml"
+    simulate_cb_output_config = "https://testdata-magda.s3-eu-west-1.amazonaws.com/simulate-ci-testing/simulate_cb_output_config.yml"
     simulate_cb_output_output_tag = 'simulated'
 
     // Limit resources so that this can run on GitHub Actions

--- a/conf/test.config
+++ b/conf/test.config
@@ -1,6 +1,6 @@
 /*
  * ---------------------------------------------------------------------
- *  lifebit-ai/simulate test_basic_sim_vcf_plink_gwas_stats config file
+ *  lifebit-ai/simulate test config file
  * ---------------------------------------------------------------------
  * Defines bundled input files and everything required
  * to run a fast and simple test. Use as follows:

--- a/conf/test.config
+++ b/conf/test.config
@@ -4,7 +4,7 @@
  * ---------------------------------------------------------------------
  * Defines bundled input files and everything required
  * to run a fast and simple test. Use as follows:
- * nextflow run main.nf -profile test_basic_sim_vcf_plink_gwas_stats
+ * nextflow run main.nf -profile test
  */
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,7 +8,7 @@
 // Define image used by pipeline
 
 docker.enabled = true
-process.container = 'lifebitai/simulate:latest'
+process.container = 'lifebitai/simulate:1.0dev-8cfe5ae'
 
 // Global default params, used in configs
 params {

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,7 +8,7 @@
 // Define image used by pipeline
 
 docker.enabled = true
-process.container = 'lifebitai/simulate:1.0dev-8cfe5ae'
+process.container = 'quay.io/lifebitai/simulate:5c999c5'
 
 // Global default params, used in configs
 params {
@@ -141,5 +141,4 @@ profiles {
   test { includeConfig 'conf/test.config' }
   cb { includeConfig 'conf/cb.config' }
 }
-
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -139,6 +139,7 @@ def check_max(obj, type) {
 
 profiles {
   test { includeConfig 'conf/test.config' }
+  cb { includeConfig 'conf/cb.config' }
 }
 
 


### PR DESCRIPTION
## This PR does the following

- It adds additional CI testing for one specific GCTA flag
- It adds a testing profile for testing the ability for the pipeline to simulate Cohort Browser (CB) output data

## Details:

- Correct a few outdated header information in `test.config` (still had name of original config file)
- Re-ordered matrices in `various_flags_test` in `ci.yml` to match the order of flags in `nextflow.config`
- Added a matrix for `--gwas_simulation_replicates`
- Uploaded the `testdata/simulate_cb_output_config.yml` file to my own S3 bucket for now and made a `conf/cb.config` file. Then added a specific test inside `ci.yml`

## Comments:

- I originally tried adding more matrices to the `various_flags_test` to reflect as many optional flags as possible but this results in huge number of test (>50) so decided to keep just the most relevant (and if possible binary) flags for now.

## Testing:

- Latest GitHub Actions were successful
- Testing on CloudOS:
https://cloudos.lifebit.ai/app/jobs/5fc7f230cc96a20112a71ad3

(successfull but still get the weird non-100% complete I have encountered before, even though all results are there and all processes are successfull according to `stdout`)
