### PR TITLE
Refactors hapgen simulation step to correct awk bug and allow simulation of >40,000 individuals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL description="Docker image containing all requirements for lifebit-ai/simul
       author="magda@lifebit.ai"
 
 RUN apt-get update -y  \ 
-    && apt-get install -y wget zip procps \
+    && apt-get install -y wget zip procps gawk \
     && rm -rf /var/lib/apt/lists/*
 
 COPY environment.yml /

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,7 +8,7 @@
 // Define image used by pipeline
 
 docker.enabled = true
-process.container = 'quay.io/lifebitai/simulate:5c999c5'
+process.container = 'quay.io/lifebitai/simulate:latest'
 
 // Global default params, used in configs
 params {

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,6 @@ params {
   // 1 - Workflow flags
   
   outdir                        = './results'
-  cpus_high_memory              = 1
   reference_1000G               = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/ALL_1000G_phase1integrated_v3_impute.tgz"
   legend_for_hapgen2            = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/all_leg.tar.gz"
   num_participants              = false
@@ -40,12 +39,6 @@ params {
   tracedir = "${params.outdir}/pipeline_info"
 
 }
-
-process {
-  
-  withLabel: high_memory {
-    cpus = params.cpus_high_memory
-  }
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
 env {

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,7 @@ params {
   // 1 - Workflow flags
   
   outdir                        = './results'
+  cpus_high_memory              = 1
   reference_1000G               = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/ALL_1000G_phase1integrated_v3_impute.tgz"
   legend_for_hapgen2            = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/all_leg.tar.gz"
   num_participants              = false
@@ -41,12 +42,10 @@ params {
 }
 
 process {
-
+  
   withLabel: high_memory {
-    cpus = 16
+    cpus = params.cpus_high_memory
   }
-
-}
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
 env {

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,8 +21,8 @@ params {
   num_participants              = false
   effective_population_size     = false  
   mutation_rate                 = false 
-  simulate_vcf                  = true
-  simulate_plink                = true
+  simulate_vcf                  = false
+  simulate_plink                = false
   simulate_gwas_sum_stats       = false
   gwas_cases_proportion         = 0.5
   gwas_pheno_trait_type         = 'binary'

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ process.container = 'quay.io/lifebitai/simulate:latest'
 params {
 
   // 1 - Workflow flags
-  
+  cpus_high_memory              = 4
   outdir                        = './results'
   reference_1000G               = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/ALL_1000G_phase1integrated_v3_impute.tgz"
   legend_for_hapgen2            = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/simulate/all_leg.tar.gz"
@@ -38,6 +38,12 @@ params {
   help = false
   tracedir = "${params.outdir}/pipeline_info"
 
+}
+
+process {
+  withLabel: high_memory {
+    cpus = params.cpus_high_memory
+  }
 }
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
@@ -83,4 +89,3 @@ profiles {
   test { includeConfig 'conf/test.config' }
   cb { includeConfig 'conf/cb.config' }
 }
-


### PR DESCRIPTION
# This PR does the following:

It refactors the `hapgen` simulation step to correct the `awk` bug and hence allow the simulation of >40,000 individuals. 

Context:
Prior to this update, the following error would occur when simulating `hapgen` files, in the Nextflow process `simulate_gen_and_sample`:
```
awk: program limit exceeded: maximum number of fields size=32767
	FILENAME="chr1-simulated_hapgen.gen" FNR=1 NR=1
```

# Details:

The error was not caused by `hapgen`: `hapgen` runs normally and produces the outputs as expected. Instead, the error was caused by the `awk` commands following the `hapgen` commands - i.e: the following commands:
```
    # Update/correct the output files:
    # (1) Replace fake chromosome names (hapgen2 outputs: "snp_0", "snp_1" instead of a unique chromosome name)
    # (2) Remove the dash from the sample names (but not the header) - required for downstream PLINK steps
    awk '$1="!{chr}"' !{chr}-simulated_hapgen-!{num_participants}ind.gen > !{chr}-simulated_hapgen-!{num_participants}ind-updated.gen
    sed '1d' !{chr}-simulated_hapgen-!{num_participants}ind.sample | sed 's/id1_/id/g' | sed 's/id2_/id/g' | awk 'BEGIN{print "ID_1 ID_2 missing pheno"}{print}' > !{chr}-simulated_hapgen-!{num_participants}ind-updated.sample
```

Therefore to resolve this, `awk` (more specifically `mawk`) - the default version in `Debian` was replaced by `gawk` which does not have a limit number of fields.

**Specific changes**:
- In `Dockerfile`, added `gawk` as a dependency. Now, `awk` commands will call `gawk` (no need to change any command in `main.nf`.

- In `nextflow.config`, ensure `latest` tagged container is used.

- Unrelated change: changed `--simulate-vcf` and `--simulate-plink` to `false` in `nextflow.config`. Indeed, all docs say their default is `false`.

- Further testing and optimization of specific resources requires (cpus, instance type) may be required.

- Exposes cpus_high_memory as a parameter

# Lifebit CloudOS testing:

Simulating 40,000 individuals (successful): 
https://cloudos.lifebit.ai/app/jobs/60008c3357851f0112a93626

Simulating 100,000 individuals (successful):
https://cloudos.lifebit.ai/app/jobs/60008c5257851f0112a936c7

Simulating 500,000 individuals (successful):
https://cloudos.lifebit.ai/app/jobs/6000819b57851f0112a90d73

# CI testing:

Successful: https://github.com/lifebit-ai/simulate/actions/runs/486006140